### PR TITLE
Fix concurrent issues

### DIFF
--- a/nkf.go
+++ b/nkf.go
@@ -69,7 +69,7 @@ func Convert(str string, options string) (string, error) {
 	cstr := (*C.uchar)(unsafe.Pointer(C.CString(str)))
 	defer C.free(unsafe.Pointer(cstr))
 
-	coptions := C.CString(options)
+	coptions := (*C.uchar)(unsafe.Pointer(C.CString(options)))
 	defer C.free(unsafe.Pointer(coptions))
 
 	coutput := C.gonkf_convert(cstr, C.int(len(str)), coptions, C.int(len(options)))

--- a/nkf.go
+++ b/nkf.go
@@ -11,10 +11,9 @@ import "C"
 import (
 	"errors"
 	"strings"
+	"sync"
 	"unsafe"
 )
-
-var noMemoryError = errors.New("failed to allocate memory")
 
 type Encoding string
 
@@ -58,7 +57,15 @@ const (
 	ENCODING_UNKNOWN          Encoding = "UNKNOWN"
 )
 
+var (
+	noMemoryError = errors.New("failed to allocate memory")
+	lock          = sync.Mutex{}
+)
+
 func Convert(str string, options string) (string, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
 	cstr := (*C.uchar)(unsafe.Pointer(C.CString(str)))
 	defer C.free(unsafe.Pointer(cstr))
 
@@ -77,6 +84,9 @@ func Convert(str string, options string) (string, error) {
 }
 
 func Guess(str string) (Encoding, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
 	cstr := (*C.uchar)(unsafe.Pointer(C.CString(str)))
 	defer C.free(unsafe.Pointer(cstr))
 

--- a/nkf.h
+++ b/nkf.h
@@ -1,10 +1,8 @@
 #ifndef __NKF_H_LOADED__
 #define __NKF_H_LOADED__
 
-#include <stdio.h>
-
 unsigned char *
-gonkf_convert(unsigned char *str, int str_size, char *opts, int opts_size);
+gonkf_convert(unsigned char *str, int str_size, unsigned char *opts, int opts_size);
 
 const char *
 gonkf_convert_guess(unsigned char *str, int str_size);

--- a/nkf_test.go
+++ b/nkf_test.go
@@ -44,16 +44,17 @@ func TestConvert(t *testing.T) {
 }
 
 func TestCovertConcurrent(t *testing.T) {
-	c := make(chan bool, 3)
+	n := 3
+	c := make(chan bool, n)
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < n; i++ {
 		go func() {
 			TestConvert(t)
 			c <- true
 		}()
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < n; i++ {
 		<-c
 	}
 }

--- a/nkf_test.go
+++ b/nkf_test.go
@@ -43,6 +43,21 @@ func TestConvert(t *testing.T) {
 	}
 }
 
+func TestCovertConcurrent(t *testing.T) {
+	c := make(chan bool, 3)
+
+	for i := 0; i < 3; i++ {
+		go func() {
+			TestConvert(t)
+			c <- true
+		}()
+	}
+
+	for i := 0; i < 3; i++ {
+		<-c
+	}
+}
+
 func TestGuess(t *testing.T) {
 	t.Skip()
 }


### PR DESCRIPTION
## Why

It's not goroutine-safe...

```
runtime stack:
runtime.throw(0x41c1c40, 0x2a)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/panic.go:530 +0x90
runtime.sigpanic()
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/sigpanic_unix.go:12 +0x5a

goroutine 9 [syscall, locked to thread]:
runtime.cgocall(0x4108d90, 0xc8200294d0, 0xc800000000)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/cgocall.go:123 +0x11b fp=0xc820029480 sp=0xc820029450
github.com/creasty/go-nkf._Cfunc_gonkf_convert(0x44031d0, 0x24, 0x4400020, 0x8, 0x0)
        github.com/creasty/go-nkf/_test/_obj_test/_cgo_gotypes.go:80 +0x42 fp=0xc8200294d0 sp=0xc820029480
github.com/creasty/go-nkf.Convert(0x41bd440, 0x24, 0x41907b0, 0x8, 0x0, 0x0, 0x0, 0x0)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf.go:68 +0x16c fp=0xc820029540 sp=0xc8200294d0
github.com/creasty/go-nkf.TestConvert(0xc82008c090)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:35 +0x194 fp=0xc820029788 sp=0xc820029540
github.com/creasty/go-nkf.TestCovertConcurrent.func1(0xc82008c090, 0xc820054150)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:51 +0x21 fp=0xc8200297b0 sp=0xc820029788
runtime.goexit()
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc8200297b8 sp=0xc8200297b0
created by github.com/creasty/go-nkf.TestCovertConcurrent
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:53 +0x73

goroutine 1 [chan receive]:
testing.RunTests(0x41d00e8, 0x428b980, 0x3, 0x3, 0xc82000a501)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/testing/testing.go:583 +0x8d2
testing.(*M).Run(0xc820049ef8, 0xc82000a580)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/testing/testing.go:515 +0x81
main.main()
        github.com/creasty/go-nkf/_test/_testmain.go:58 +0x117

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/asm_amd64.s:1998 +0x1

goroutine 6 [chan receive]:
github.com/creasty/go-nkf.TestCovertConcurrent(0xc82008c090)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:57 +0xb6
testing.tRunner(0xc82008c090, 0x428b998)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/testing/testing.go:473 +0x98
created by testing.RunTests
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/testing/testing.go:582 +0x892

goroutine 7 [syscall, locked to thread]:
github.com/creasty/go-nkf._Cfunc_gonkf_convert(0x4700020, 0x24, 0x4700050, 0x8, 0x0)
        github.com/creasty/go-nkf/_test/_obj_test/_cgo_gotypes.go:80 +0x42
github.com/creasty/go-nkf.Convert(0x41bd440, 0x24, 0x41907b0, 0x8, 0x0, 0x0, 0x0, 0x0)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf.go:68 +0x16c
github.com/creasty/go-nkf.TestConvert(0xc82008c090)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:35 +0x194
github.com/creasty/go-nkf.TestCovertConcurrent.func1(0xc82008c090, 0xc820054150)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:51 +0x21
created by github.com/creasty/go-nkf.TestCovertConcurrent
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:53 +0x73

goroutine 8 [runnable, locked to thread]:
github.com/creasty/go-nkf._Cfunc_CString(0x41bd440, 0x24, 0x0)
        github.com/creasty/go-nkf/_test/_obj_test/_cgo_gotypes.go:49 +0x28
github.com/creasty/go-nkf.Convert(0x41bd440, 0x24, 0x41907b0, 0x8, 0x0, 0x0, 0x0, 0x0)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf.go:62 +0x53
github.com/creasty/go-nkf.TestConvert(0xc82008c090)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:35 +0x194
github.com/creasty/go-nkf.TestCovertConcurrent.func1(0xc82008c090, 0xc820054150)
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:51 +0x21
created by github.com/creasty/go-nkf.TestCovertConcurrent
        /Users/ykiwng/go/src/github.com/creasty/go-nkf/nkf_test.go:53 +0x73
[signal 0xb code=0x1 addr=0x90 pc=0x90]

runtime stack:
runtime.throw(0x41c1c40, 0x2a)
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/panic.go:530 +0x90
runtime.sigpanic()
        /Users/ykiwng/.anyenv/envs/goenv/versions/1.6/src/runtime/sigpanic_unix.go:12 +0x5a
exit status 2
FAIL    github.com/creasty/go-nkf       0.021s
```
## What
- Mutex
- Refactor
